### PR TITLE
oauth for tef

### DIFF
--- a/govcd/api_vcd_versions.go
+++ b/govcd/api_vcd_versions.go
@@ -73,7 +73,7 @@ var _ = vcdVersionToApiVersion
 //
 // vCD version mapping to API version support https://code.vmware.com/doc/preview?id=8072
 func (cli *Client) APIVCDMaxVersionIs(versionConstraint string) bool {
-	err := cli.vcdFetchSupportedVersions()
+	err := cli.vcdFetchsupportedVersions()
 	if err != nil {
 		util.Logger.Printf("[ERROR] could not retrieve supported versions: %s", err)
 		return false
@@ -115,10 +115,10 @@ func (cli *Client) APIClientVersionIs(versionConstraint string) bool {
 	return isSupported
 }
 
-// vcdFetchSupportedVersions retrieves list of supported versions from
+// vcdFetchsupportedVersions retrieves list of supported versions from
 // /api/versions endpoint and stores them in VCDClient for future uses.
 // It only does it once.
-func (cli *Client) vcdFetchSupportedVersions() error {
+func (cli *Client) vcdFetchsupportedVersions() error {
 	// Only fetch /versions if it is not stored already
 	numVersions := len(cli.supportedVersions.VersionInfos)
 	if numVersions > 0 {
@@ -132,7 +132,10 @@ func (cli *Client) vcdFetchSupportedVersions() error {
 	suppVersions := new(SupportedVersions)
 	_, err := cli.ExecuteRequest(apiEndpoint.String(), http.MethodGet,
 		"", "error fetching versions: %s", nil, suppVersions)
-
+	if err != nil {
+		util.Logger.Printf("[ERROR] error in vcdFetchsupportedVersions: %v", err)
+		return fmt.Errorf("Error in vcdFetchsupportedVersions: %v", err)
+	}
 	cli.supportedVersions = *suppVersions
 
 	// Log all supported API versions in one line to help identify vCD version from logs
@@ -209,7 +212,7 @@ func (cli *Client) apiVersionMatchesConstraint(version, versionConstraint string
 
 // validateAPIVersion fetches API versions
 func (cli *Client) validateAPIVersion() error {
-	err := cli.vcdFetchSupportedVersions()
+	err := cli.vcdFetchsupportedVersions()
 	if err != nil {
 		return fmt.Errorf("could not retrieve supported versions: %s", err)
 	}

--- a/govcd/task.go
+++ b/govcd/task.go
@@ -54,8 +54,10 @@ func (task *Task) Refresh() error {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	refreshUrl, _ := url.ParseRequestURI(task.Task.HREF)
-
+	refreshUrl, err := url.ParseRequestURI(task.Task.HREF)
+	if err != nil {
+		return fmt.Errorf("error in ParseRequestURI HREF: %s err %v", task.Task.HREF, err)
+	}
 	req := task.client.NewRequest(map[string]string{}, http.MethodGet, *refreshUrl, nil)
 
 	resp, err := checkResp(task.client.Http.Do(req))

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -722,8 +722,10 @@ func (vm *VM) GetQuestion() (types.VmPendingQuestion, error) {
 	apiEndpoint.Path += "/question"
 
 	req := vm.client.NewRequest(map[string]string{}, http.MethodGet, *apiEndpoint, nil)
-
 	resp, err := vm.client.Http.Do(req)
+	if err != nil {
+		return types.VmPendingQuestion{}, err
+	}
 
 	// vCD security feature - on no question return 403 access error
 	if http.StatusForbidden == resp.StatusCode {


### PR DESCRIPTION
EDGECLOUD-4606 O-Auth / API GW support for TEF

TEF's access to VCD requires the following:
- Connection to an O-Auth server to get a token
- All API requests must then go thru an API GW and pass along the token.  
- Mutual TLS is used on all connections
- The token must be re-used until it expires (8 hours)
- Even though we authenticate via TEF's O-Auth server, we still have to do the regular VCD authentication, just passing thru the API GW

Changes summary:
- Optional changes to VCD authentication are done here plus mTLS
- Create CopyClient method which will be used by infra code to create new VCD clients which have all the same tokens and other strings within of the original client, but can be run in different threads without conflict. This is to deal with the fact we have to re-use their tokens for a long time
- because everything is tunneled thru the API GW, we have to manipulate all the subsequent API calls and replace the URLs.  The way VCD APIs work, you do a query and get an XML form back with a bunch of HREFs, which are how other objects are accessed.  All of these URLs in TEF's environment show the internal URL which we cannot access, so hence the need for "fixUrlForAgw" to change the
- Fix some VCD crashes I ran into because the err responses were not being checked
- Create a new function UploadOvfUrl to allow an OVF to be uploaded from a remote URL rather than uploaded via the API. This is needed because trying to upload a multi-gig file thru their APIGW is not workable, and we don't have access to the UI

Infra changes to follow once I get this done.