### PR TITLE
fix content-type

### DIFF
--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -192,7 +192,7 @@ func (vm *VM) PowerOnAndForceCustomization() error {
 	}
 
 	task, err := vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
-		"", "error powering on VM with customization: %s", powerOnAndCustomize)
+		"application/*+xml", "error powering on VM with customization: %s", powerOnAndCustomize)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
When sending via the TEF API GW, the Power On command fails with 415 Invalid Content Type. Why this only matters when thru the API GW, but adding a Content-Type header 'application/*+xml" resolves the issue and also works without the API GW.
